### PR TITLE
Add theme toggle for dark and light modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
 
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles.css">
+<script>
+  const theme = localStorage.getItem('theme');
+  if (theme === 'light') document.documentElement.classList.add('light');
+</script>
 </head>
 <body>
   <div class="app" id="app">
@@ -16,10 +20,16 @@
         <span class="badge">words: <b id="wordCount">50</b></span>
         <span class="badge">timer: <b id="timerBadge">30s</b></span>
       </div>
-      <div class="hud" id="hud">
-        <div class="stat"><div class="l">wpm</div><div class="v" id="wpm">0</div></div>
-        <div class="stat"><div class="l">accuracy</div><div class="v" id="acc">100%</div></div>
-        <div class="stat"><div class="l">time</div><div class="v" id="time">30.0</div></div>
+      <div style="display:flex; align-items:center; gap:10px">
+        <div class="hud" id="hud">
+          <div class="stat"><div class="l">wpm</div><div class="v" id="wpm">0</div></div>
+          <div class="stat"><div class="l">accuracy</div><div class="v" id="acc">100%</div></div>
+          <div class="stat"><div class="l">time</div><div class="v" id="time">30.0</div></div>
+        </div>
+        <label class="switch" aria-label="toggle theme">
+          <input type="checkbox" id="themeToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -14,13 +14,25 @@ window.addEventListener('DOMContentLoaded', () => {
   const TIMER_LEN = 30; // default 30s
   const WORD_GOAL_DEFAULT = 50;
 
-  const COLORS = {
-    bg: "#0d1623",
-    ink: "#9bb0c9",
-    correct: "#7cffc4",
-    wrong: "#ff6b6b",
-    caret: CARET_COLOR
+  const THEMES = {
+    dark: {
+      bg: "#0d1623",
+      ink: "#9bb0c9",
+      correct: "#7cffc4",
+      wrong: "#ff6b6b",
+      caret: CARET_COLOR
+    },
+    light: {
+      bg: "#ffffff",
+      ink: "#243b53",
+      correct: "#3ba776",
+      wrong: "#ff6b6b",
+      caret: CARET_COLOR
+    }
   };
+
+  let currentTheme = localStorage.getItem('theme') === 'light' ? 'light' : 'dark';
+  let COLORS = { ...THEMES[currentTheme] };
 
   const SAMPLES = [
     "monkeys type better when coffee is near and bugs run away",
@@ -80,7 +92,8 @@ window.addEventListener('DOMContentLoaded', () => {
     btnRepeat: document.getElementById('btnRepeat'),
     btnNext: document.getElementById('btnNext'),
     btnOwn: document.getElementById('btnOwn'),
-    sink: document.getElementById('sink')
+    sink: document.getElementById('sink'),
+    themeToggle: document.getElementById('themeToggle')
   };
 
   // ---------- state ----------
@@ -457,6 +470,13 @@ window.addEventListener('DOMContentLoaded', () => {
     history.replaceState({}, '', url);
   }
 
+  function applyTheme(theme){
+    document.documentElement.classList.toggle('light', theme === 'light');
+    COLORS = { ...THEMES[theme] };
+    localStorage.setItem('theme', theme);
+    currentTheme = theme;
+  }
+
   els.restart.addEventListener('click', () => reset(false));     // repeat
   els.newText.addEventListener('click', () => reset(true));       // next
   els.shorter.addEventListener('click', () => { wordsTarget = clamp(wordsTarget-5, 5, 200); els.wordCount.textContent = wordsTarget; reset(true); syncURL(); });
@@ -469,6 +489,9 @@ window.addEventListener('DOMContentLoaded', () => {
   els.btnRepeat.addEventListener('click', () => { hideResultsPage(); reset(false); });
   els.btnNext.addEventListener('click',   () => { hideResultsPage(); reset(true);  });
   els.btnOwn.addEventListener('click',    () => { hideResultsPage(); showOverlay(); });
+  els.themeToggle.addEventListener('change', () => {
+    applyTheme(els.themeToggle.checked ? 'light' : 'dark');
+  });
 
   document.addEventListener('keydown', handleKeydown);
   els.sink.addEventListener('input', handleInput);
@@ -477,6 +500,8 @@ window.addEventListener('DOMContentLoaded', () => {
   // ---------- init ----------
   els.wordCount.textContent = WORD_GOAL_DEFAULT;
   els.timerBadge.textContent = `${timerSeconds}s`;
+  applyTheme(currentTheme);
+  els.themeToggle.checked = currentTheme === 'light';
 
   measure();
   state.text = pickText(wordsTarget);

--- a/styles.css
+++ b/styles.css
@@ -1,52 +1,88 @@
 :root{
-  --bg:#0b0f14; --panel:#111823; --ink:#e8f0ff; --muted:#9bb0c9;
-  --accent:#5ee397; --accent-2:#ffd166; --bad:#ff6b6b; --good:#7cffc4;
+  --bg:#0b0f14;
+  --bg-gradient-start:#1a2433;
+  --bg-gradient-end:#0b0f14;
+  --app-gradient-start:#101621;
+  --app-gradient-end:#0d1420;
+  --panel:#111823;
+  --ink:#e8f0ff;
+  --muted:#9bb0c9;
+  --accent:#5ee397;
+  --accent-2:#ffd166;
+  --bad:#ff6b6b;
+  --good:#7cffc4;
   --yellow:#e2b714;
+  --border:#1d2a3b;
+  --surface:#0b131f;
+  --surface-border:#1b2a3e;
+  --canvas-bg:#0d1623;
+  --canvas-border:#1c2a3f;
+  --active-bg:#0f1a2a;
+  --active-ink:#ffffff;
+  --hover-border:#2a3d58;
+}
+:root.light{
+  --bg:#ffffff;
+  --bg-gradient-start:#ffffff;
+  --bg-gradient-end:#f1f5fb;
+  --app-gradient-start:#ffffff;
+  --app-gradient-end:#f1f5fb;
+  --panel:#f5f7fa;
+  --ink:#243b53;
+  --muted:#5a677d;
+  --border:#cfd8e6;
+  --surface:#ffffff;
+  --surface-border:#cfd8e6;
+  --canvas-bg:#ffffff;
+  --canvas-border:#cfd8e6;
+  --active-bg:#e0e7f3;
+  --active-ink:#000000;
+  --hover-border:#9cb4d8;
 }
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
-  margin:0; background:radial-gradient(80vmax 80vmax at 80% -10%, #1a2433 0%, #0b0f14 55%);
+  margin:0; background:radial-gradient(80vmax 80vmax at 80% -10%, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 55%);
   color:var(--ink); font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Cantarell,Noto Sans,Arial;
   display:grid; place-items:center; padding:18px;
 }
 .app{
   width:min(980px,96vw);
-  background:linear-gradient(180deg,#101621,#0d1420);
-  border:1px solid #1d2a3b; border-radius:16px;
+  background:linear-gradient(180deg,var(--app-gradient-start),var(--app-gradient-end));
+  border:1px solid var(--border); border-radius:16px;
   box-shadow:0 10px 30px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.03);
   padding:16px; position:relative;
 }
 .row{display:flex; align-items:center; gap:12px; flex-wrap:wrap; justify-content:space-between}
 .title{font-weight:800; text-transform:lowercase}
-.badge{font-size:12px; color:var(--muted); background:#0b131f; border:1px solid #1b2a3e; border-radius:999px; padding:6px 10px}
+.badge{font-size:12px; color:var(--muted); background:var(--surface); border:1px solid var(--surface-border); border-radius:999px; padding:6px 10px}
 .hud{display:flex; gap:10px; flex-wrap:wrap}
-.stat{background:#0b131f; border:1px solid #1b2a3e; padding:8px 10px; border-radius:10px; min-width:88px; text-align:center}
+.stat{background:var(--surface); border:1px solid var(--surface-border); padding:8px 10px; border-radius:10px; min-width:88px; text-align:center}
 .stat .l{font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.6px}
 .stat .v{font-size:18px; font-weight:700; margin-top:2px}
 .controls{display:flex; gap:8px; margin-top:10px; flex-wrap:wrap; align-items:center}
 /* base buttons (top controls) */
-button{background:#0b131f; border:1px solid #1b2a3e; color:var(--ink); padding:8px 12px; border-radius:10px; cursor:pointer}
-button:hover{box-shadow:0 0 0 2px #1b2a3e inset}
+button{background:var(--surface); border:1px solid var(--surface-border); color:var(--ink); padding:8px 12px; border-radius:10px; cursor:pointer}
+button:hover{box-shadow:0 0 0 2px var(--surface-border) inset}
 .spacer{flex:1 1 auto}
-canvas.stage{display:block; width:100%; height:420px; border-radius:12px; background:#0d1623; border:1px solid #1c2a3f}
+canvas.stage{display:block; width:100%; height:420px; border-radius:12px; background:var(--canvas-bg); border:1px solid var(--canvas-border)}
 #sink{position:absolute; left:-9999px; top:-9999px; opacity:0; width:0; height:0; caret-color:transparent}
 
 /* segmented timer */
-.seg{display:inline-flex; background:#0b131f; border:1px solid #1b2a3e; border-radius:12px; overflow:hidden}
-.seg button{border:0; background:transparent; padding:8px 10px; border-right:1px solid #1b2a3e; border-radius:0}
+.seg{display:inline-flex; background:var(--surface); border:1px solid var(--surface-border); border-radius:12px; overflow:hidden}
+.seg button{border:0; background:transparent; padding:8px 10px; border-right:1px solid var(--surface-border); border-radius:0}
 .seg button:last-child{border-right:0}
-.seg button.is-active{background:#0f1a2a; color:#fff}
+.seg button.is-active{background:var(--active-bg); color:var(--active-ink)}
 
 /* custom text modal */
 .overlay{position:absolute; inset:0; display:none; align-items:center; justify-content:center;
   background:rgba(0,0,0,.5); backdrop-filter:saturate(120%) blur(2px); padding:20px; z-index:10;}
 .overlay.show{display:flex;}
-.sheet{width:min(880px,95vw); background:#0d1623; border:1px solid #1c2a3f; border-radius:12px; padding:16px;
+.sheet{width:min(880px,95vw); background:var(--canvas-bg); border:1px solid var(--canvas-border); border-radius:12px; padding:16px;
   box-shadow:0 10px 30px rgba(0,0,0,.6);}
 .sheet h3{margin:0 0 8px 0; font-size:16px}
-.sheet textarea{width:100%; height:220px; resize:vertical; background:#0b131f; color:#e8f0ff;
-  border:1px solid #1b2a3e; border-radius:10px; padding:10px; font-size:14px; line-height:1.5;
+.sheet textarea{width:100%; height:220px; resize:vertical; background:var(--surface); color:var(--ink);
+  border:1px solid var(--surface-border); border-radius:10px; padding:10px; font-size:14px; line-height:1.5;
   font-family:'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;}
 .sheet .actions{display:flex; gap:8px; margin-top:10px; justify-content:flex-end}
 
@@ -60,7 +96,7 @@ canvas.stage{display:block; width:100%; height:420px; border-radius:12px; backgr
 .kv{min-width:120px}
 .kv .k{color:var(--muted); font-size:12px; text-transform:uppercase; letter-spacing:.6px}
 .kv .v{font-weight:700; font-size:18px; margin-top:2px}
-.chart{width:100%; height:240px; border:1px solid #1b2a3e; border-radius:10px; background:#0b131f}
+.chart{width:100%; height:240px; border:1px solid var(--surface-border); border-radius:10px; background:var(--surface)}
 
 /* centered, flat results buttons */
 .res-actions{
@@ -69,10 +105,18 @@ canvas.stage{display:block; width:100%; height:420px; border-radius:12px; backgr
 }
 .res-actions button{
   appearance:none; background:var(--panel); color:var(--ink); padding:10px 16px; border-radius:12px;
-  border:1px solid #1b2a3e; box-shadow:none; font-weight:600; letter-spacing:.2px; cursor:pointer;
+  border:1px solid var(--surface-border); box-shadow:none; font-weight:600; letter-spacing:.2px; cursor:pointer;
   transition:border-color .15s ease, transform .12s ease; flex:0 0 auto;
 }
-.res-actions button:hover{border-color:#2a3d58; transform:translateY(-1px)}
+.res-actions button:hover{border-color:var(--hover-border); transform:translateY(-1px)}
 .res-actions button:active{transform:none}
 .res-actions button:focus-visible{outline:none; border-color:var(--yellow)}
+
+/* theme switch */
+.switch{position:relative; display:inline-block; width:40px; height:20px;}
+.switch input{opacity:0; width:0; height:0;}
+.slider{position:absolute; cursor:pointer; top:0; left:0; right:0; bottom:0; background:var(--surface); border:1px solid var(--surface-border); transition:.2s; border-radius:20px;}
+.slider:before{position:absolute; content:""; height:16px; width:16px; left:2px; bottom:2px; background:var(--ink); transition:.2s; border-radius:50%;}
+.switch input:checked + .slider{background:var(--active-bg);}
+.switch input:checked + .slider:before{transform:translateX(20px);}
 


### PR DESCRIPTION
## Summary
- add a theme switch to toggle between dark and light appearances
- introduce CSS variables and light-theme overrides
- update canvas colors based on selected theme with persistence

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/typepracticegame/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689decaf86dc8325bbf86d0bd7aa98e6