### PR TITLE
Add dark and light mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,13 @@
         <span class="badge">words: <b id="wordCount">50</b></span>
         <span class="badge">timer: <b id="timerBadge">30s</b></span>
       </div>
-      <div class="hud" id="hud">
-        <div class="stat"><div class="l">wpm</div><div class="v" id="wpm">0</div></div>
-        <div class="stat"><div class="l">accuracy</div><div class="v" id="acc">100%</div></div>
-        <div class="stat"><div class="l">time</div><div class="v" id="time">30.0</div></div>
+      <div style="display:flex; align-items:center; gap:12px">
+        <div class="hud" id="hud">
+          <div class="stat"><div class="l">wpm</div><div class="v" id="wpm">0</div></div>
+          <div class="stat"><div class="l">accuracy</div><div class="v" id="acc">100%</div></div>
+          <div class="stat"><div class="l">time</div><div class="v" id="time">30.0</div></div>
+        </div>
+        <button id="themeToggle" aria-label="Toggle dark and light mode">light mode</button>
       </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const TIMER_LEN = 30; // default 30s
   const WORD_GOAL_DEFAULT = 50;
 
-  const COLORS = {
+  let COLORS = {
     bg: "#0d1623",
     ink: "#9bb0c9",
     correct: "#7cffc4",
@@ -1080,8 +1080,33 @@ window.addEventListener('DOMContentLoaded', () => {
     btnRepeat: document.getElementById('btnRepeat'),
     btnNext: document.getElementById('btnNext'),
     btnOwn: document.getElementById('btnOwn'),
-    sink: document.getElementById('sink')
+    sink: document.getElementById('sink'),
+    themeToggle: document.getElementById('themeToggle')
   };
+
+  function updateColors(){
+    const bodyStyles = getComputedStyle(document.body);
+    const canvasStyles = getComputedStyle(canvas);
+    COLORS.bg = canvasStyles.backgroundColor || COLORS.bg;
+    COLORS.ink = bodyStyles.getPropertyValue('--muted').trim() || COLORS.ink;
+    COLORS.correct = bodyStyles.getPropertyValue('--good').trim() || COLORS.correct;
+    COLORS.wrong = bodyStyles.getPropertyValue('--bad').trim() || COLORS.wrong;
+  }
+
+  // ---------- theme ----------
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'light' || (!savedTheme && window.matchMedia('(prefers-color-scheme: light)').matches)) {
+    document.body.classList.add('light');
+  }
+  updateColors();
+  els.themeToggle.textContent = document.body.classList.contains('light') ? 'dark mode' : 'light mode';
+  els.themeToggle.addEventListener('click', () => {
+    const isLight = document.body.classList.toggle('light');
+    els.themeToggle.textContent = isLight ? 'dark mode' : 'light mode';
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    updateColors();
+    if (resultsView.classList.contains('show')) drawResultChart();
+  });
 
   // ---------- state ----------
   const params = new URLSearchParams(location.search);
@@ -1388,10 +1413,11 @@ window.addEventListener('DOMContentLoaded', () => {
   function drawResultChart(){
     const c = els.resChart, g = c.getContext('2d');
     const W = c.width, H = c.height;
+    const light = document.body.classList.contains('light');
     g.clearRect(0,0,W,H);
-    g.fillStyle = "#0d1623"; g.fillRect(0,0,W,H);
+    g.fillStyle = light ? "#ffffff" : "#0d1623"; g.fillRect(0,0,W,H);
     // grid
-    g.strokeStyle = "#223148"; g.lineWidth = 1;
+    g.strokeStyle = light ? "#d0d7e2" : "#223148"; g.lineWidth = 1;
     g.beginPath(); for (let x=40; x<W; x+=60){ g.moveTo(x,20); g.lineTo(x,H-30); } g.stroke();
     g.beginPath(); for (let y=20; y<H-30; y+=30){ g.moveTo(40,y); g.lineTo(W-10,y); } g.stroke();
 

--- a/styles.css
+++ b/styles.css
@@ -76,3 +76,36 @@ canvas.stage{display:block; width:100%; height:420px; border-radius:12px; backgr
 .res-actions button:active{transform:none}
 .res-actions button:focus-visible{outline:none; border-color:var(--yellow)}
 
+/* light theme */
+body.light{
+  --ink:#0b0f14;
+  --muted:#445161;
+  background:radial-gradient(80vmax 80vmax at 80% -10%, #f0f4fa 0%, #ffffff 55%);
+  color:var(--ink);
+}
+body.light .app{
+  background:linear-gradient(180deg,#ffffff,#f0f4fa);
+  border:1px solid #d0d7e2;
+  box-shadow:0 10px 30px rgba(0,0,0,.15), inset 0 1px 0 rgba(255,255,255,.8);
+}
+body.light .badge,
+body.light .stat,
+body.light button,
+body.light .seg,
+body.light .sheet textarea,
+body.light .chart{
+  background:#ffffff;
+  border:1px solid #d0d7e2;
+  color:var(--ink);
+}
+body.light .badge{color:var(--muted);}
+body.light button:hover,
+body.light .res-actions button:hover{box-shadow:0 0 0 2px #d0d7e2 inset; border-color:#d0d7e2;}
+body.light .seg button{border-right:1px solid #d0d7e2;}
+body.light .seg button.is-active{background:#e6eaf0; color:#000;}
+body.light canvas.stage{background:#ffffff; border:1px solid #d0d7e2;}
+body.light .sheet{background:#ffffff; border:1px solid #d0d7e2;}
+body.light .label{color:var(--muted);}
+body.light .res-actions button{background:#f6f7f9; border:1px solid #d0d7e2; color:var(--ink);}
+body.light .res-actions button:hover{border-color:#c0c8d2; transform:translateY(-1px);}
+


### PR DESCRIPTION
## Summary
- Add theme toggle button to switch between dark and light modes
- Persist theme choice and redraw results chart with new colors
- Define light theme styles
- Make typing canvas colors follow selected theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e056de8248325928e7ff592b18933