### PR TITLE
Add selectable sample pools B1-C2

### DIFF
--- a/B1.js
+++ b/B1.js
@@ -1,0 +1,6 @@
+const B1_SAMPLES = [
+  "B1 learners practice with simple everyday topics.",
+  "Typing helps build confidence with familiar words and phrases.",
+  "Short stories provide good exercises at the intermediate stage.",
+  "Consistent drills improve accuracy and speed over time."
+];

--- a/B2.js
+++ b/B2.js
@@ -1,0 +1,6 @@
+const B2_SAMPLES = [
+  "Complex sentences challenge your developing typing skills.",
+  "Accuracy becomes important as texts grow in difficulty.",
+  "Explore varied topics to stay engaged during practice.",
+  "Longer passages build stamina and control in typing."
+];

--- a/C1.js
+++ b/C1.js
@@ -1,0 +1,6 @@
+const C1_SAMPLES = [
+  "Advanced learners analyze nuanced arguments with precision.",
+  "Typing drills mimic the structure of real academic essays.",
+  "Rich vocabulary allows for precise and elegant expression.",
+  "Efficient editing keeps complex topics clear and coherent."
+];

--- a/C2.js
+++ b/C2.js
@@ -1,0 +1,6 @@
+const C2_SAMPLES = [
+  "Mastery of language enables effortless shifts in style and tone.",
+  "Typing at this level mirrors spontaneous speech with ease.",
+  "Sophisticated structures demand sustained focus and accuracy.",
+  "Subtle nuances are captured through precise word choice."
+];

--- a/index.html
+++ b/index.html
@@ -36,6 +36,12 @@
         <button type="button" data-t="60">60s</button>
         <button type="button" data-t="90">90s</button>
       </div>
+      <div class="seg" id="sampleSeg" aria-label="sample pool">
+        <button type="button" data-sample="B1" class="is-active">B1</button>
+        <button type="button" data-sample="B2">B2</button>
+        <button type="button" data-sample="C1">C1</button>
+        <button type="button" data-sample="C2">C2</button>
+      </div>
       <span class="spacer"></span>
       <button id="restart">repeat (Esc / Ctrl+R)</button>
       <button id="newText">next test (Ctrl+N)</button>
@@ -90,7 +96,10 @@
   </div>
 
   <input id="sink" autocomplete="off" autocapitalize="off" spellcheck="false" />
-  <script src="samples.js"></script>
+  <script src="B1.js"></script>
+  <script src="B2.js"></script>
+  <script src="C1.js"></script>
+  <script src="C2.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -29,7 +29,14 @@ window.addEventListener('DOMContentLoaded', () => {
     caret: CARET_COLOR
   };
   let COLORS = COLORS_DARK;
-  // sample texts loaded from samples.js
+  // sample text pools
+  let SAMPLE_POOL = typeof B1_SAMPLES !== 'undefined' ? B1_SAMPLES : [];
+  const SAMPLE_POOLS = {
+    B1: typeof B1_SAMPLES !== 'undefined' ? B1_SAMPLES : [],
+    B2: typeof B2_SAMPLES !== 'undefined' ? B2_SAMPLES : [],
+    C1: typeof C1_SAMPLES !== 'undefined' ? C1_SAMPLES : [],
+    C2: typeof C2_SAMPLES !== 'undefined' ? C2_SAMPLES : []
+  };
 
   // ---------- elements ----------
   const app = document.getElementById('app');
@@ -37,6 +44,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const resultsView = document.getElementById('results');
   const timerSeg = document.getElementById('timerSeg');
+  const sampleSeg = document.getElementById('sampleSeg');
   const typingEls = [canvas, document.getElementById('controls'), document.getElementById('hud')];
   const els = {
     wpm: document.getElementById('wpm'),
@@ -117,7 +125,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function pickText(wordGoal){
     const words = [];
     while(words.length < wordGoal){
-      const w = SAMPLES[Math.floor(Math.random()*SAMPLES.length)].split(/\s+/);
+      const w = SAMPLE_POOL[Math.floor(Math.random()*SAMPLE_POOL.length)].split(/\s+/);
       words.push(...w);
     }
     return words.slice(0, wordGoal).join(' ');
@@ -453,6 +461,20 @@ window.addEventListener('DOMContentLoaded', () => {
       els.timerBadge.textContent = `${t}s`;
       reset(false);
       syncURL();
+    }
+  });
+
+  // ---------- sample pool selector ----------
+  sampleSeg.addEventListener('click', (e) => {
+    const b = e.target.closest('button[data-sample]');
+    if (!b) return;
+    const key = b.dataset.sample;
+    const pool = SAMPLE_POOLS[key];
+    if (pool && pool.length) {
+      for (const x of sampleSeg.querySelectorAll('button')) x.classList.remove('is-active');
+      b.classList.add('is-active');
+      SAMPLE_POOL = pool;
+      reset(true);
     }
   });
 


### PR DESCRIPTION
## Summary
- Add buttons and logic to choose text samples from B1/B2/C1/C2 pools
- Introduce four sample pool files and use them in the typing test
- Replace fixed sample array usage with selectable pools

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_689e1d893d2083258d32c32da7bcde5b