### PR TITLE
feat: allow selecting sample pools

### DIFF
--- a/B1.js
+++ b/B1.js
@@ -1,0 +1,5 @@
+const B1_SAMPLES = [
+  "Learning a new language can be fun and rewarding.",
+  "Practice typing to improve your speed and accuracy.",
+  "Consistent effort brings steady progress."
+];

--- a/B2.js
+++ b/B2.js
@@ -1,0 +1,5 @@
+const B2_SAMPLES = [
+  "The quick brown fox jumps over the lazy dog.",
+  "Typing challenges enhance cognitive flexibility and focus.",
+  "Efficient algorithms enable responsive applications."
+];

--- a/C1.js
+++ b/C1.js
@@ -1,0 +1,5 @@
+const C1_SAMPLES = [
+  "Complex problems often require creative yet systematic solutions.",
+  "Mastering touch typing allows programmers to translate ideas effortlessly.",
+  "Optimization strategies must consider both time and space complexity."
+];

--- a/C2.js
+++ b/C2.js
@@ -1,0 +1,5 @@
+const C2_SAMPLES = [
+  "In computer science, abstraction layers permit scalable architectures to emerge.",
+  "Latency considerations subtly influence distributed system design decisions.",
+  "Resilience in software stems from fault tolerance and rigorous validation."
+];

--- a/index.html
+++ b/index.html
@@ -36,6 +36,12 @@
         <button type="button" data-t="60">60s</button>
         <button type="button" data-t="90">90s</button>
       </div>
+      <div class="seg" id="poolSeg" aria-label="sample pool">
+        <button type="button" data-pool="B1" class="is-active">B1</button>
+        <button type="button" data-pool="B2">B2</button>
+        <button type="button" data-pool="C1">C1</button>
+        <button type="button" data-pool="C2">C2</button>
+      </div>
       <span class="spacer"></span>
       <button id="restart">repeat (Esc / Ctrl+R)</button>
       <button id="newText">next test (Ctrl+N)</button>
@@ -90,8 +96,11 @@
   </div>
 
   <input id="sink" autocomplete="off" autocapitalize="off" spellcheck="false" />
-  <script src="samples.js"></script>
-  <script src="main.js"></script>
-</body>
-</html>
+    <script src="B1.js"></script>
+    <script src="B2.js"></script>
+    <script src="C1.js"></script>
+    <script src="C2.js"></script>
+    <script src="main.js"></script>
+  </body>
+  </html>
 

--- a/main.js
+++ b/main.js
@@ -29,7 +29,9 @@ window.addEventListener('DOMContentLoaded', () => {
     caret: CARET_COLOR
   };
   let COLORS = COLORS_DARK;
-  // sample texts loaded from samples.js
+  // sample text pools
+  const SAMPLE_POOLS = { B1: B1_SAMPLES, B2: B2_SAMPLES, C1: C1_SAMPLES, C2: C2_SAMPLES };
+  let SAMPLES = SAMPLE_POOLS.B1;
 
   // ---------- elements ----------
   const app = document.getElementById('app');
@@ -37,6 +39,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const ctx = canvas.getContext('2d');
   const resultsView = document.getElementById('results');
   const timerSeg = document.getElementById('timerSeg');
+  const poolSeg = document.getElementById('poolSeg');
   const typingEls = [canvas, document.getElementById('controls'), document.getElementById('hud')];
   const els = {
     wpm: document.getElementById('wpm'),
@@ -453,6 +456,18 @@ window.addEventListener('DOMContentLoaded', () => {
       els.timerBadge.textContent = `${t}s`;
       reset(false);
       syncURL();
+    }
+  });
+
+  poolSeg.addEventListener('click', (e) => {
+    const b = e.target.closest('button[data-pool]');
+    if (!b) return;
+    const p = b.dataset.pool;
+    if (p && SAMPLE_POOLS[p]) {
+      for (const x of poolSeg.querySelectorAll('button')) x.classList.remove('is-active');
+      b.classList.add('is-active');
+      SAMPLES = SAMPLE_POOLS[p];
+      reset(true);
     }
   });
 


### PR DESCRIPTION
## Summary
- add buttons to switch between B1, B2, C1 and C2 sample pools
- wire new sample pool selector into main logic
- provide sample text pools for each level

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689e1d893d2083258d32c32da7bcde5b